### PR TITLE
Fix the regex to export all used buckets (ex.: nerd-fonts)

### DIFF
--- a/scoop/scoop.export.all.ps1
+++ b/scoop/scoop.export.all.ps1
@@ -10,7 +10,7 @@ function Export-Buckets {
     )
 
     # export BUCKETS
-    scoop export | Select-String '\[(\w+)\]' | ForEach-Object { $_.matches.groups[1].value } | Select-Object -unique > "$Path\scoop.buckets.txt"
+    scoop export | Select-String '\[([\w\-]+)\]' | ForEach-Object { $_.matches.groups[1].value } | Select-Object -unique > "$Path\scoop.buckets.txt"
 }
 
 function Export-AppNameOnly {


### PR DESCRIPTION
This should solve a little issue for used bucket names that includes hyphen