### PR TITLE
Force tag update on cleanup

### DIFF
--- a/git/gitconfig.txt
+++ b/git/gitconfig.txt
@@ -79,13 +79,13 @@
     # Usage: git clean-merged [branch name (default: main)]
     #        e.g. git clean-merged
     #        e.g. git clean-merged feature/foo
-    clean-merged = "!f() { local targetBranch=${1:-main} && git switch $targetBranch && git pull -p --tags && git delete-merged $targetBranch; }; f"
+    clean-merged = "!f() { local targetBranch=${1:-main} && git switch $targetBranch && git pull -f -p --tags && git delete-merged $targetBranch; }; f"
 
     # Switches and pulls latest from given branch, prunes remote branches, fetches tags and deletes branches squashed into given branch.
     # Usage: git clean-squashed [branch name (default: main)]
     #        e.g. git clean-squashed
     #        e.g. git clean-squashed feature/foo
-    clean-squashed = "!f() { local targetBranch=${1:-main} && git switch $targetBranch && git pull -p --tags && git delete-squashed $targetBranch; }; f"
+    clean-squashed = "!f() { local targetBranch=${1:-main} && git switch $targetBranch && git pull -f -p --tags && git delete-squashed $targetBranch; }; f"
 
     # Alias for clean-squashed.
     # Usage: git tidy [branch name (default: main)]


### PR DESCRIPTION
Enables existing tags update. e.g. a major version tag will always point to its corresponding latest commit